### PR TITLE
edits to initiate.json

### DIFF
--- a/character_tracker/archetypes/initiate.json
+++ b/character_tracker/archetypes/initiate.json
@@ -41,7 +41,6 @@
             "10": "Tyrannical leaders",
             "11": "Obsolete gear",
             "12": "Poor",
-            "13": "",
             "limit": "1"
         },
     },
@@ -93,7 +92,7 @@
     },
     "keys": {
         "moves": {
-            "act_under_pressure": ["1", "2", "3", "7", "8"],
+            "act_under_pressure": [],
             "kick_some_ass": [],
             "help_out": ["8"],
             "investigate": ["9"],


### PR DESCRIPTION
Fixed a line in key/moves that I had copy/pasted on accident.
Deleted a empty bad-sect row.
Left the empty haven thing under 'keys' in case it breaks something.

Question: I left the copy/pasted luck description, but i don't see those on the initiate playbook OR the other ones ("When you spend a point of Luck, you discover something happening". Where u get those?